### PR TITLE
Allow prefix to be specified as an environment variable.

### DIFF
--- a/src/Commands/ApiDocsGeneratorCommand.php
+++ b/src/Commands/ApiDocsGeneratorCommand.php
@@ -48,9 +48,20 @@ class ApiDocsGeneratorCommand extends Command {
 	 */
 	public function fire()
 	{
-
-       $prefix = is_null($this->argument('prefix')) ? $this->ask('What is the API Prefix?  i.e. "api/v1"') : $this->argument('prefix');
-       $this->info('Generating ' . $prefix . ' API Documentation.');
+		if (!is_null($this->argument('prefix'))) {
+			// Command line argument takes 1st precedence.
+			$prefix = $this->argument('prefix');
+		}
+		else {
+			// Check for an environment variable, so you don't have to type
+			// the prefix in each time. Otherwise, ask them.
+			if (!empty(getenv('APIDOCS_PREFIX'))) {
+				$prefix = getenv('APIDOCS_PREFIX');
+			} else {
+				$prefix = $this->ask('What is the API Prefix?  i.e. "api/v1"');
+			}
+		}
+		$this->info('Generating ' . $prefix . ' API Documentation.');
 
 	   // generate the docs
 	   $this->generator->make($prefix);


### PR DESCRIPTION
Change the fire method to look for an environment var (in your .env) to use as a prefix.
If it doesn't find one it will revert to how it always worked with asking for it.
