### PR TITLE
Change require to require-dev.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ This Laravel package provides an API Documentation generator based upon your Rou
 
 Begin by installing this package through Composer. Edit your project's `composer.json` file to require `f2m2/apidocs`.
 
-    "require": {
-        "laravel/framework": "~5.0.*",
+    "require-dev": {
         "f2m2/apidocs": "dev-master"
     }
 


### PR DESCRIPTION
This package is not necessary on production and should be set as a dev dependency. Removed Laravel from the dependency list because that wouldn't be a dev dependency.
