### PR TITLE
Allow height of description to expand beyond 40px

### DIFF
--- a/src/templates/assets/css/main.css
+++ b/src/templates/assets/css/main.css
@@ -259,9 +259,7 @@ ul#navigation li.active > a {
     font-weight: 200;
     padding-right: 6px;
 }
-.endpoint-short-desc{
-    height: 40px;
-    line-height: 40px;
+.endpoint-short-desc {
     margin: 10px;
     padding: 0 15px 0 0;
 }


### PR DESCRIPTION
Fixed an issue when using long descriptions within the phpdoc's resulting in text overflowing from the description box.

Before: https://dl.dropboxusercontent.com/u/459290/github-prs/before.png
After: https://dl.dropboxusercontent.com/u/459290/github-prs/after.png
